### PR TITLE
Calculate payload length for non "0x" prefix payload definition

### DIFF
--- a/src/injection.c
+++ b/src/injection.c
@@ -55,8 +55,17 @@ injection_init()
     signal(SIGHUP, injection_clean_exit);
 
     if(hex_payload)
+    {
         if((payload_len = format_hex_payload(payload)) == 0)
             fprintf(stdout, "Warning: Hex payload formatted incorrectly.\n");
+    }
+    else if(payload)
+    {
+	    payload_len = strlen(payload);
+#ifdef DEBUG
+	    fprintf(stdout, "DEBUG: payload_len=%d\n", payload_len);
+#endif
+    }
 
     if(s_d_port != NULL)
     {

--- a/src/shape_tcp_hdr.c
+++ b/src/shape_tcp_hdr.c
@@ -48,6 +48,8 @@ shape_tcp_hdr(libnet_t *pkt_d)
 
     flags = retrieve_tcp_flags();
 
+    // If packet length is provided, create a packet with a sequence
+    // as payload
     if(pkt_len)
     {
         payload = generate_padding(hdr_len + IPV4_H, pkt_len);

--- a/src/shape_udp_hdr.c
+++ b/src/shape_udp_hdr.c
@@ -41,6 +41,8 @@ shape_udp_hdr(libnet_t *pkt_d)
     if(rand_s_port)
         s_port = (u_int16_t)retrieve_rand_int(P_UINT16);
 
+    // If packet length is provided, create a packet with a sequence
+    // as payload
     if(pkt_len)
     {
         payload = generate_padding(hdr_len + IPV4_H, pkt_len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -622,6 +622,17 @@ parse_port_range(u_int8_t *rangestr)
     return range;
 }
 
+/**
+ * Creates fake payload of size
+ *   (packet length) - (current header length)
+ *
+ * The payload consists of u_int8_t values from from 48 .. 126
+ * followed by 33 .. 126 as many times as needed.
+ *
+ * @param clen - Header length (already being used in the packet)
+ * @param dlen - Packet length
+ * @return malloc'ed u_int8_t array with the new payload
+ */
 u_int8_t *
 generate_padding(u_int16_t clen, u_int16_t dlen)
 {
@@ -640,18 +651,13 @@ generate_padding(u_int16_t clen, u_int16_t dlen)
 
     string = malloc(sizeof(u_int8_t *) * (dlen - clen + 1));
 
-    for(i = 0; clen < dlen; i++, clen++)
+    for(i = 0; clen < dlen; ++i, ++clen)
     {
         if(c > 126)
             c = 33;
-
-        if(i == 0)
-            sprintf(string, "%c", c);
-        else
-            sprintf(string, "%s%c", string, c);
-
-        c++;
+        string[i] = c++;
     }
+    string[i] = 0;
 
     return string;
 }


### PR DESCRIPTION
If payload is specified without the "0x " prefix, calculate payload length by strlen. Also simplify the generate_padding() method to avoid calling sprintf() repeatedly.
---

According to the documentation, the "-p" argument can be used to specify the payload.

"""
       -p payload
            This option defines the payload portion of the header.
            Hex payload should be prefixed with '0x' with each value
            separated by a whitespace.
            ASCII Example: -p 'hello, this is my packet'
            Hex Example: -p '0x 70 61 63 6B 69 74'
"""

The payload length is only calculated when it is specified in the hex form and not the ASCII form (this patch fixes this bug). Here is how you can try reproducing this bug:

REPRODUCING THE BUG
-------------------

   (In terminal 1, run tcpdump)
      # tcpdump -i lo -n port 3939 -vvv -xxx
  
   (In terminal 2, run packit)
      $ sudo packit -t TCP -i lo -s 127.0.0.1 -d 127.0.0.1 -S 3939 -D 3938 -F PA -q 100 -a 100 -p abcd
    
You will notice in tcpdump:

   23:20:54.292453 IP (tos 0x0, ttl 128, id 640, offset 0, flags [none], proto TCP (6), length 40)
       127.0.0.1.3939 > 127.0.0.1.3938: Flags [P.], cksum 0x923d (correct), seq 0, ack 1, win 65535, length 0  <<< tcp payload length = 0 bytes
           0x0000:  0000 0000 0000 0000 0000 0000 0800 4500
           0x0010:  0028 0280 0000 8006 3a4e 7f00 0001 7f00
           0x0020:  0001 0f63 0f62 0000 0064 0000 0064 5018
           0x0030:  ffff 923d 0000  <<< payload missing

PROVIDING PAYLOAD IN HEX WORKS
------------------------------

   (In terminal 1, run tcpdump)
      # tcpdump -i lo -n port 3939 -vvv -xxx
  
   (In terminal 2, run packit)
      $ sudo packit -t TCP -i lo -s 127.0.0.1 -d 127.0.0.1 -S 3939 -D 3938 -F PA -q 100 -a 100 -p "0x 61 62 63 64"
    
You will notice in tcpdump:

   23:21:59.110457 IP (tos 0x0, ttl 128, id 45004, offset 0, flags [none], proto TCP (6), length 44)
       127.0.0.1.3939 > 127.0.0.1.3938: Flags [P.], cksum 0xcd72 (correct), seq 0:4, ack 1, win 65535, length 4  <<< tcp payload length = 4 bytes
           0x0000:  0000 0000 0000 0000 0000 0000 0800 4500
           0x0010:  002c afcc 0000 8006 8cfd 7f00 0001 7f00
           0x0020:  0001 0f63 0f62 0000 0064 0000 0064 5018
           0x0030:  ffff cd72 0000 6162 6364   <<< payload present in the last 4 bytes

If the packet length is explicitly provided, we generate some sequence of numbers as the payload instead of using the payload that's provided. This behavior is not changed. 

This pull request also simplifies the fake payload generation code to avoid calling sprintf repeatedly (and documents it).