### PR TITLE
Fix all compiler warnings and incorrect ETH_BROADCAST definition

### DIFF
--- a/src/capture.c
+++ b/src/capture.c
@@ -105,7 +105,7 @@ capture_init(char *filter, u_int64_t cnt)
     else
         fprintf(stdout, "using device: %s ", g_device);
 
-    if(g_filter)
+    if(filter)
         fprintf(stdout, "[%s]", filter);
 
     fprintf(stdout, "\n");

--- a/src/capture.h
+++ b/src/capture.h
@@ -31,6 +31,6 @@
 #include "print_capture.h"
 
 void process_packets(u_int8_t *, struct pcap_pkthdr *, u_int8_t *);
-void capture_init(u_int8_t *, u_int64_t);
+void capture_init(char *, u_int64_t);
 
 #endif /* __CAPTURE_H */

--- a/src/define_defaults.c
+++ b/src/define_defaults.c
@@ -29,15 +29,15 @@
 void
 define_injection_defaults()
 {
-    cnt = (p_mode == M_INJECT) ? 1 : 30;
-    inj_cnt = 1;
-    cap_cnt = 0;
+    g_cnt = (g_p_mode == M_INJECT) ? 1 : 30;
+    g_inj_cnt = 1;
+    g_cap_cnt = 0;
     rawip = 0;
     s_port = 0;
     rand_s_port = 1;
     s_d_port = "0";
     d_port = 0;
-    rand_d_port = (p_mode == M_TRACE) ? 1 : 0;
+    rand_d_port = (g_p_mode == M_TRACE) ? 1 : 0;
     r_timeout = 1;
     burst_rate = 1;
     init_type = 1;
@@ -45,12 +45,12 @@ define_injection_defaults()
     interval_usec = 0;
     payload = NULL;
     payload_len = 0;
-    hdr_len = 0;
+    g_hdr_len = 0;
     display = 1;
-    verbose = 0;
-    resolve = 1;
+    g_verbose = 0;
+    g_resolve = 1;
     link_layer = 0;
-    resolve = 0;
+    g_resolve = 0;
 
     return;
 }

--- a/src/exit.c
+++ b/src/exit.c
@@ -29,7 +29,7 @@
 void
 injection_clean_exit(int sig)
 {
-    u_int8_t a[2];
+    char a[2];
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: injection_clean_exit(%d)\n", sig);
@@ -74,7 +74,7 @@ capture_clean_exit(int sig)
     fprintf(stdout, "\n");
 
     capture_stats();
-    pcap_close(pkt);
+    pcap_close(g_pkt);
 
     fprintf(stdout, "\n");
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -53,8 +53,8 @@
 #define IPV4_DEFAULT                    0x00000000		/* 0.0.0.0 */
 #define IPV4_BROADCAST                  "255.255.255.255"
 #define MASK_DEFAULT                    "255.255.255.0"
-#define ETH_DEFAULT                     0x000000000000		/* 00:00:00:00:00:00 */
-#define ETH_BROADCAST                   0xffffffffffff		/* ff:ff:ff:ff:ff:ff */
+#define ETH_DEFAULT                     "00:00:00:00:00:00"
+#define ETH_BROADCAST                   "ff:ff:ff:ff:ff:ff"
 
 #define ARP_H            		0x1c    /* ARP header:          28 bytes */
 #define DNS_H                 		0xc     /* DNS header base:     12 bytes */

--- a/src/globals.h
+++ b/src/globals.h
@@ -140,17 +140,17 @@
 char w_file[OPT_MAXLEN];
 char r_file[OPT_MAXLEN];
 
-pcap_t *pkt;
-u_int8_t tr_fin;
-u_int8_t *filter;
-u_int8_t *device;
-u_int16_t hdr_len;
-u_int16_t pkt_len;
-u_int16_t verbose;
-u_int16_t resolve;
-u_int16_t p_mode;
-u_int64_t cnt;
-u_int64_t inj_cnt;
-u_int64_t cap_cnt;
+pcap_t *g_pkt;
+u_int8_t g_tr_fin;
+char *g_filter;
+char *g_device;
+u_int16_t g_hdr_len;
+u_int16_t g_pkt_len;
+u_int16_t g_verbose;
+u_int16_t g_resolve;
+u_int16_t g_p_mode;
+u_int64_t g_cnt;
+u_int64_t g_inj_cnt;
+u_int64_t g_cap_cnt;
 
 #endif /* __GLOBALS_H */

--- a/src/init.c
+++ b/src/init.c
@@ -40,7 +40,7 @@ injection_struct_init()
     ahdr_o.r_eaddr = ETH_DEFAULT;
 
     memset(&ip4hdr_o, 0, sizeof(struct ip4hdr_opts));
-    ip4hdr_o.ttl = (p_mode == M_INJECT) ? 128 : 1;
+    ip4hdr_o.ttl = (g_p_mode == M_INJECT) ? 128 : 1;
     ip4hdr_o.frag = 0;
     ip4hdr_o.tos = 0;
     ip4hdr_o.sum = 0;

--- a/src/inject_defs.h
+++ b/src/inject_defs.h
@@ -40,7 +40,7 @@ struct ip4hdr_opts
     u_int16_t id;                  /* id number */
     u_int16_t rand_id;
 
-    u_int8_t *s_addr;              /* src address string */
+    char *s_addr;                  /* src address string */
     u_int8_t *src_addr_o1;
     u_int8_t *src_addr_o2;
     u_int8_t *src_addr_o3;
@@ -48,7 +48,7 @@ struct ip4hdr_opts
     u_int32_t n_saddr;             /* src address network byte order */
     u_int16_t rand_s_addr;
 
-    u_int8_t *d_addr;              /* dst address string */
+    char *d_addr;                  /* dst address string */
     u_int8_t *dst_addr_o1;
     u_int8_t *dst_addr_o2;
     u_int8_t *dst_addr_o3;
@@ -99,7 +99,7 @@ struct icmp4hdr_opts
     u_int16_t seqn;                /* icmp4 sequence number */
     u_int16_t rand_seqn;
 
-    u_int8_t *gw;                       /* gateway redirect address */
+    char *gw;                           /* gateway redirect address */
     u_int16_t rand_gw;
 
     u_int16_t orig_id;             /* original id */
@@ -111,19 +111,19 @@ struct icmp4hdr_opts
     u_int16_t orig_sum;                 /* original checksum */
     u_int16_t orig_p;                   /* original protocol */
 
-    u_int8_t *orig_s_addr;              /* original source address */
+    char *orig_s_addr;                  /* original source address */
     u_int16_t rand_orig_s_addr;
 
     u_int16_t orig_s_port;         /* original source port */
     u_int16_t rand_orig_s_port;
 
-    u_int8_t *orig_d_addr;              /* original destination address */
+    char *orig_d_addr;                 /* original destination address */
     u_int16_t rand_orig_d_addr;
 
     u_int16_t orig_d_port;         /* original destination port */
     u_int16_t rand_orig_d_port;
 
-    u_int8_t *mask;                     /* icmp4 mask */
+    char *mask;                         /* icmp4 mask */
 
     u_int32_t otime;                    /* original timestamp */
     u_int32_t rtime;                    /* recieved timestamp */
@@ -135,30 +135,30 @@ struct enethdr_opts
     u_int16_t rand_s_addr;
     u_int16_t rand_d_addr;
 
-    u_int8_t *s_addr;                   /* source ethernet address string */
-    u_int8_t shw_addr[18];
-    u_int8_t *d_addr;                   /* destination ethernet address string */
-    u_int8_t dhw_addr[18];
+    char *s_addr;                      /* source ethernet address string */
+    char shw_addr[18];
+    char *d_addr;                      /* destination ethernet address string */
+    char dhw_addr[18];
 } ehdr_o;
 
 struct arphdr_opts
 {
     u_int16_t op_type;                  /* arp operation */
 
-    u_int8_t *s_paddr;                  /* sender protocol address */
+    char *s_paddr;                      /* sender protocol address */
     u_int16_t rand_s_paddr;
 
-    u_int8_t *r_paddr;                  /* receiver protocol address */
+    char *r_paddr;                      /* receiver protocol address */
     u_int16_t rand_r_paddr;
 
-    u_int8_t *s_eaddr;                  /* sender ethernet address */
+    char *s_eaddr;                      /* sender ethernet address */
     u_int16_t rand_s_eaddr;
 
-    u_int8_t *r_eaddr;                  /* receiver ethernet address */
+    char *r_eaddr;                      /* receiver ethernet address */
     u_int16_t rand_r_eaddr;
 
-    u_int8_t shw_addr[18];
-    u_int8_t rhw_addr[18];
+    char shw_addr[18];
+    char rhw_addr[18];
 } ahdr_o;
 
 libnet_t *pkt_d;
@@ -175,7 +175,7 @@ u_int16_t injection_type;
 u_int16_t r_timeout;
 u_int16_t burst_rate;
 u_int16_t payload_len;
-u_int8_t *payload;
+char *payload;
 u_int8_t hex_payload;
 char *s_d_port;
 u_int8_t hwaddr_p[18];

--- a/src/injection.c
+++ b/src/injection.c
@@ -45,7 +45,7 @@ injection_init()
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: injection_init()\n");
-    fprintf(stdout, "DEBUG: cnt: %lld, interval_sec %d\n", g_cnt, interval_sec);
+    fprintf(stdout, "DEBUG: cnt: %lu, interval_sec %d\n", g_cnt, interval_sec);
     fprintf(stdout, "DEBUG: p_mode: %d  burst_rate: %d\n", g_p_mode, burst_rate);
 #endif
 
@@ -144,7 +144,7 @@ with_response(u_int32_t port_range)
     for(i = 1; i < g_cnt + 1; i++)
     {
 #ifdef DEBUG
-        fprintf(stdout, "DEBUG: for() inj_cnt: %lld  cnt: %lld\n", g_inj_cnt, g_cnt);
+        fprintf(stdout, "DEBUG: for() inj_cnt: %lu  cnt: %lu\n", g_inj_cnt, g_cnt);
 #endif
 
         if(dstp) i = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -31,12 +31,12 @@
 void
 parse_capture_options(int argc, char *argv[])
 {
-    p_mode = M_CAPTURE;
-    cnt = 0;
-    cap_cnt = 0;
+    g_p_mode = M_CAPTURE;
+    g_cnt = 0;
+    g_cap_cnt = 0;
     snap_len = SNAPLEN_DEFAULT;
-    resolve = 3;
-    verbose = 0;
+    g_resolve = 3;
+    g_verbose = 0;
     display = 1;
     link_layer = 0;
 
@@ -49,7 +49,7 @@ parse_capture_options(int argc, char *argv[])
         switch(opt)
         {
             case 'c':
-                cnt = (u_int64_t)atoi(optarg);
+                g_cnt = (u_int64_t)atoi(optarg);
                 break;
 
             case 'e':
@@ -61,7 +61,7 @@ parse_capture_options(int argc, char *argv[])
 		break;
 
             case 'i':
-                if(!(device = strdup(optarg)))
+                if(!(g_device = strdup(optarg)))
 		    fatal_error("Memory unavailable for: %s", optarg);
 		
                 break;
@@ -79,11 +79,11 @@ parse_capture_options(int argc, char *argv[])
 		break;
 
             case 'v':
-               verbose = 1;
+               g_verbose = 1;
                break;
 
             case 'n':
-                resolve--;
+                g_resolve--;
 	        break;
 
 	    case 'x': case 'X':
@@ -92,7 +92,7 @@ parse_capture_options(int argc, char *argv[])
         }
     }
 
-    capture_init(argv[optind], cnt);
+    capture_init(argv[optind], g_cnt);
 
     return;
 }
@@ -100,15 +100,15 @@ parse_capture_options(int argc, char *argv[])
 void
 parse_inject_options(int argc, char *argv[], u_int16_t iopt)
 {
-    u_int8_t *opts = NULL;
+    char *opts = NULL;
 
 #ifdef DEBUG
-    fprintf(stdout, "DEBUG: parse_inject_options(%d)\n", p_mode);
+    fprintf(stdout, "DEBUG: parse_inject_options(%d)\n", g_p_mode);
 #endif
 
     if(getuid() != 0) fatal_error("Sorry, you're not root!");
 
-    p_mode = iopt;
+    g_p_mode = iopt;
 
     define_injection_defaults();
     injection_struct_init();
@@ -150,7 +150,7 @@ parse_inject_options(int argc, char *argv[], u_int16_t iopt)
 		else
                 if(!strncasecmp(optarg, "ARP", 3))
                 {
-                    if(p_mode == M_TRACE)
+                    if(g_p_mode == M_TRACE)
                         fatal_error("ARP is not supported with trace mode.");
 #ifdef DEBUG
                     fprintf(stdout, "DEBUG: ARP injection\n");
@@ -166,7 +166,7 @@ parse_inject_options(int argc, char *argv[], u_int16_t iopt)
                 else
                 if(!strncasecmp(optarg, "RARP", 4))
                 {
-                    if(p_mode == M_TRACE)
+                    if(g_p_mode == M_TRACE)
                         fatal_error("RARP is not supported with trace mode.");
 #ifdef DEBUG
                     fprintf(stdout, "DEBUG: RARP injection\n");
@@ -183,7 +183,7 @@ parse_inject_options(int argc, char *argv[], u_int16_t iopt)
                 else
                 if(!strncasecmp(optarg, "RAWIP", 3))
                 {
-                    if(p_mode == M_TRACE)
+                    if(g_p_mode == M_TRACE)
                         fatal_error("RAW is not supported with trace mode.");
 #ifdef DEBUG
                     fprintf(stdout, "DEBUG: raw IP injection\n");
@@ -203,7 +203,7 @@ parse_inject_options(int argc, char *argv[], u_int16_t iopt)
                 if(optind > 1) optind--;
                 injection_type = ETHERTYPE_IP;
 
-                if(p_mode == M_TRACE)
+                if(g_p_mode == M_TRACE)
                 {
                     ip4hdr_o.p = IPPROTO_ICMP;
                     opts = "b:c:C:d:e:E:fg:G:hH:i:j:J:k:K:l:L:m:M:n:N:o:O:p:P:Q:Rs:t:T:U:vw:z:Z:";
@@ -244,10 +244,10 @@ parse_inject:
                 break;
 
             case 'c':
-                if(p_mode == M_TRACE && (u_int64_t)atoi(optarg) > 0xFF)
+                if(g_p_mode == M_TRACE && (u_int64_t)atoi(optarg) > 0xFF)
                     fatal_error("Count cannot exceed max TTL value");
 
-                cnt = (u_int64_t)atoi(optarg);
+                g_cnt = (u_int64_t)atoi(optarg);
                 break;
 
             case 'C':
@@ -343,8 +343,8 @@ parse_inject:
                 break;
 
 	    case 'h':
-                if(p_mode == M_INJECT)
-	            p_mode = M_INJECT_RESPONSE;	
+                if(g_p_mode == M_INJECT)
+	            g_p_mode = M_INJECT_RESPONSE;	
 
 		break;
 
@@ -353,7 +353,7 @@ parse_inject:
                 break;
 
             case 'i':
-                if(!(device = strdup(optarg)))
+                if(!(g_device = strdup(optarg)))
 		    fatal_error("Memory unavailable for: %s", optarg);
 
                 break;
@@ -467,7 +467,7 @@ parse_inject:
                 break;
 
             case 'R':
-                resolve = 0;
+                g_resolve = 0;
                 break;
 
             case 's':
@@ -505,7 +505,7 @@ parse_inject:
                 break;
 
             case 'v':
-                verbose = 1;
+                g_verbose = 1;
                 break;
 
             case 'V':
@@ -564,7 +564,7 @@ parse_inject:
                 break;
 
             case 'Z':
-                pkt_len = (u_int16_t)atoi(optarg);
+                g_pkt_len = (u_int16_t)atoi(optarg);
                 break;
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -48,7 +48,7 @@
 
 #define OPT_MAXLEN 32
 
-u_int32_t opt;
+int32_t opt;
 char *optarg;
 
 void parse_capture_options(int, char *[]);

--- a/src/print_arp_hdr.c
+++ b/src/print_arp_hdr.c
@@ -29,7 +29,7 @@
 void
 print_arp_hdr(u_int8_t *packet)
 {
-    u_int8_t *arp_t, *arp_hw_t;
+    char *arp_t, *arp_hw_t;
     u_int16_t frame_t;
 
     struct libnet_arp_hdr *ahdr;
@@ -38,13 +38,13 @@ print_arp_hdr(u_int8_t *packet)
     fprintf(stdout, "DEBUG: print_arp_hdr()\n");
 #endif
 
-    ahdr = (struct libnet_arp_hdr *)(packet + hdr_len);
+    ahdr = (struct libnet_arp_hdr *)(packet + g_hdr_len);
 
     arp_t = retrieve_arp_type(htons(ahdr->ar_op));
     arp_hw_t = retrieve_arp_hw_type(htons(ahdr->ar_hrd));
 
     fprintf(stdout, "ARP header:  Type: %s(%d)\n", arp_t, htons(ahdr->ar_op));
-    frame_t = ntohs(*(u_int16_t *)(packet + hdr_len - sizeof(u_int16_t)));
+    frame_t = ntohs(*(u_int16_t *)(packet + g_hdr_len - sizeof(u_int16_t)));
 
     fprintf(stdout, "%s header:  Type: %s(%d)\n",
             (frame_t == ETHERTYPE_REVARP) ? "RARP": "ARP",

--- a/src/print_capture.c
+++ b/src/print_capture.c
@@ -47,29 +47,29 @@ print_capture(struct pcap_pkthdr *pkthdr, u_int8_t *packet)
             fprintf(stdout, "DEBUG: ether_type: ip\n");
 #endif
 
-            if(p_mode == M_CAPTURE)
-                print_separator(1, 2, "PID %lld", (u_int64_t)cap_cnt + 1);
+            if(g_p_mode == M_CAPTURE)
+                print_separator(1, 2, "PID %lld", (u_int64_t)g_cap_cnt + 1);
             else
-            if(p_mode == M_INJECT_RESPONSE)
-                print_separator(1, 2, "RCV %lld", (u_int64_t)inj_cnt);
+            if(g_p_mode == M_INJECT_RESPONSE)
+                print_separator(1, 2, "RCV %lld", (u_int64_t)g_inj_cnt);
 
-            iphdr = (struct libnet_ipv4_hdr *)(packet + hdr_len);
+            iphdr = (struct libnet_ipv4_hdr *)(packet + g_hdr_len);
 
-            if(p_mode == M_TRACE && !verbose)
+            if(g_p_mode == M_TRACE && !g_verbose)
             {
                  print_ipv4_hdr(iphdr);
 
-                 tr_icmphdr = (struct libnet_icmpv4_hdr *)(packet + IPV4_H + hdr_len);
+                 tr_icmphdr = (struct libnet_icmpv4_hdr *)(packet + IPV4_H + g_hdr_len);
                  if(tr_icmphdr->icmp_type != 11 || tr_icmphdr->icmp_code != 0)
-                     tr_fin = 1;
+                     g_tr_fin = 1;
             }
             else
             {
-                if(p_mode != M_TRACE)
+                if(g_p_mode != M_TRACE)
                     print_ts(pkthdr->ts);
                 else
                 if(iphdr->ip_p != IPPROTO_ICMP)
-                    tr_fin = 1;
+                    g_tr_fin = 1;
 
 #ifdef DEBUG
 	        fprintf(stdout, "DEBUG: ip_p: %d\n", iphdr->ip_p);
@@ -95,8 +95,8 @@ print_capture(struct pcap_pkthdr *pkthdr, u_int8_t *packet)
                 if(link_layer)
                     print_ethernet_hdr(ehdr);
 		
-                if(dump_pkt && pkthdr->caplen > hdr_len)
-                    print_packet_hexdump(packet + hdr_len, pkthdr->caplen - hdr_len);
+                if(dump_pkt && pkthdr->caplen > g_hdr_len)
+                    print_packet_hexdump(packet + g_hdr_len, pkthdr->caplen - g_hdr_len);
             }
         }
         else
@@ -108,23 +108,23 @@ print_capture(struct pcap_pkthdr *pkthdr, u_int8_t *packet)
                     (ehdr->ether_type == ETHERTYPE_REVARP) ? "RARP" : "ARP");
 #endif
 
-            if(p_mode == M_CAPTURE)
-                print_separator(1, 2, "PID %lld", (u_int64_t)cap_cnt + 1);
+            if(g_p_mode == M_CAPTURE)
+                print_separator(1, 2, "PID %lld", (u_int64_t)g_cap_cnt + 1);
             else
-            if(p_mode == M_INJECT_RESPONSE)
-                print_separator(1, 2, "RCV %lld", (u_int64_t)inj_cnt);
+            if(g_p_mode == M_INJECT_RESPONSE)
+                print_separator(1, 2, "RCV %lld", (u_int64_t)g_inj_cnt);
 
             print_ts(pkthdr->ts);
             print_arp_hdr(packet);
 	    print_ethernet_hdr(ehdr);
 
             if(dump_pkt)
-                if(pkthdr->caplen > hdr_len)
-                    print_packet_hexdump(packet + hdr_len, pkthdr->caplen - hdr_len);
+                if(pkthdr->caplen > g_hdr_len)
+                    print_packet_hexdump(packet + g_hdr_len, pkthdr->caplen - g_hdr_len);
 	}
     }
 
-    cap_cnt++;
+    g_cap_cnt++;
 
     return;
 }

--- a/src/print_icmpv4_hdr.c
+++ b/src/print_icmpv4_hdr.c
@@ -28,8 +28,7 @@
 void
 print_icmpv4_hdr(u_int8_t *packet)
 {
-    u_int8_t *s_addr, *d_addr;
-    u_int8_t *icmp_t, *icmp_c;
+    char *s_addr, *d_addr, *icmp_t, *icmp_c;
 
     struct libnet_icmpv4_hdr *icmphdr;
 
@@ -41,10 +40,10 @@ print_icmpv4_hdr(u_int8_t *packet)
 #define icmp_iphdr icmphdr->dun.ip.idi_ip
 #endif
 
-    icmphdr = (struct libnet_icmpv4_hdr *)(packet + IPV4_H + hdr_len);
+    icmphdr = (struct libnet_icmpv4_hdr *)(packet + IPV4_H + g_hdr_len);
 
-    s_addr = (u_int8_t *)malloc(sizeof(s_addr));
-    d_addr = (u_int8_t *)malloc(sizeof(d_addr));
+    s_addr = malloc(sizeof(s_addr));
+    d_addr = malloc(sizeof(d_addr));
 
     icmp_t = retrieve_icmp_type(icmphdr->icmp_type);
     icmp_c = retrieve_icmp_code(icmphdr->icmp_type, icmphdr->icmp_code);
@@ -58,7 +57,7 @@ print_icmpv4_hdr(u_int8_t *packet)
                 icmp_c, icmphdr->icmp_code,
                 libnet_addr2name4(ntohl(icmphdr->hun.gateway), 0));
 
-            if(verbose)
+            if(g_verbose)
             {
                 s_addr = libnet_addr2name4(icmp_iphdr.ip_src.s_addr, 0);
                 d_addr = libnet_addr2name4(icmp_iphdr.ip_dst.s_addr, 0);
@@ -84,7 +83,7 @@ print_icmpv4_hdr(u_int8_t *packet)
             if(icmphdr->icmp_code == ICMP_UNREACH_NEEDFRAG)
                 fprintf(stdout, "MTU: %d  Pad: %d  ", ntohs(icmphdr->hun.frag.mtu), ntohs(icmphdr->hun.frag.pad));
 
-            if(verbose)
+            if(g_verbose)
             {
                 s_addr = libnet_addr2name4(icmp_iphdr.ip_src.s_addr, 0);
                 d_addr = libnet_addr2name4(icmp_iphdr.ip_dst.s_addr, 0);
@@ -107,7 +106,7 @@ print_icmpv4_hdr(u_int8_t *packet)
         case ICMP_TIMXCEED: case ICMP_PARAMPROB:
             fprintf(stdout, "Code: %s(%d)  ", icmp_c, icmphdr->icmp_code);
 
-            if(verbose)
+            if(g_verbose)
             {
                 s_addr = libnet_addr2name4(icmp_iphdr.ip_src.s_addr, 0);
                 d_addr = libnet_addr2name4(icmp_iphdr.ip_dst.s_addr, 0);
@@ -165,7 +164,7 @@ print_icmpv4_hdr(u_int8_t *packet)
     fprintf(stdout, "\n");
 
     if(icmphdr->icmp_type != 11 || icmphdr->icmp_code != 0)
-        tr_fin = 1;
+        g_tr_fin = 1;
 
     return;
 }

--- a/src/print_injection.c
+++ b/src/print_injection.c
@@ -30,7 +30,7 @@
 void
 print_injection_details()
 {
-    u_int8_t *arp_t, *icmp_t, *icmp_c = NULL;
+    char *arp_t, *icmp_t, *icmp_c = NULL;
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: print_injection() init_type: %d\n", init_type);
@@ -68,7 +68,7 @@ print_injection_details()
 
             fprintf(stdout, "TCP header:  Src Port: %d  ", s_port);
 
-            if(p_mode == M_INJECT_RESPONSE)
+            if(g_p_mode == M_INJECT_RESPONSE)
                 fprintf(stdout, "Dst Port: %d  ", d_port);
             else
                 fprintf(stdout, "Dst Port(s): %s  ", s_d_port);
@@ -161,7 +161,7 @@ print_injection_details()
 	    ip4hdr_o.s_addr, ip4hdr_o.d_addr);
 	
 	fprintf(stdout, "\t     TTL: %d  ID: %d  TOS: 0x%X  Len: %d  ",
-	    ip4hdr_o.ttl, ip4hdr_o.id, (u_int8_t)ip4hdr_o.tos, hdr_len);
+	    ip4hdr_o.ttl, ip4hdr_o.id, (u_int8_t)ip4hdr_o.tos, g_hdr_len);
 
         if(rawip)
             fprintf(stdout, "IP Protocol: %d  ", ip4hdr_o.p);

--- a/src/print_ipv4_hdr.c
+++ b/src/print_ipv4_hdr.c
@@ -28,7 +28,7 @@
 void
 print_ipv4_hdr(struct libnet_ipv4_hdr *iphdr)
 {
-    u_int8_t *s_addr, *d_addr;
+    char *s_addr, *d_addr;
 
     struct in_addr ip_src, ip_dst;
 
@@ -36,14 +36,14 @@ print_ipv4_hdr(struct libnet_ipv4_hdr *iphdr)
     fprintf(stdout, "DEBUG: print_ipv4_hdr()\n");
 #endif
 
-    s_addr = (u_int8_t *)malloc(sizeof(s_addr));
-    d_addr = (u_int8_t *)malloc(sizeof(d_addr));
+    s_addr = malloc(sizeof(s_addr));
+    d_addr = malloc(sizeof(d_addr));
 
     memset(&ip_src, 0, sizeof(struct in_addr));
     memset(&ip_dst, 0, sizeof(struct in_addr));
 
-    s_addr = libnet_addr2name4(iphdr->ip_src.s_addr, ((resolve == 1 || resolve == 3) ? 1 : 0));
-    d_addr = libnet_addr2name4(iphdr->ip_dst.s_addr, ((resolve == 1 || resolve == 3) ? 1 : 0));
+    s_addr = libnet_addr2name4(iphdr->ip_src.s_addr, ((g_resolve == 1 || g_resolve == 3) ? 1 : 0));
+    d_addr = libnet_addr2name4(iphdr->ip_dst.s_addr, ((g_resolve == 1 || g_resolve == 3) ? 1 : 0));
 
     fprintf(stdout, "IP header:   Src Address: %s  Dst Address: %s\n", s_addr, d_addr);
 

--- a/src/print_tcp_hdr.c
+++ b/src/print_tcp_hdr.c
@@ -28,7 +28,7 @@
 void
 print_tcp_hdr(u_int8_t *packet)
 {
-    u_int8_t flags[7];
+    char flags[7];
 
     struct libnet_tcp_hdr *tcphdr;
     struct servent *port_src, *port_dst;
@@ -44,7 +44,7 @@ print_tcp_hdr(u_int8_t *packet)
     memset(port_dst, 0, sizeof(struct servent));
     memset(flags, 0, sizeof(flags));
 
-    tcphdr = (struct libnet_tcp_hdr *)(packet + IPV4_H + hdr_len);
+    tcphdr = (struct libnet_tcp_hdr *)(packet + IPV4_H + g_hdr_len);
 
     if(tcphdr->th_flags & TH_URG)
         strcat(flags, "U");

--- a/src/print_udp_hdr.c
+++ b/src/print_udp_hdr.c
@@ -34,7 +34,7 @@ print_udp_hdr(u_int8_t *packet)
     fprintf(stdout, "DEBUG: print_udp_hdr()\n");
 #endif
 
-    udphdr = (struct libnet_udp_hdr *)(packet + IPV4_H + hdr_len);
+    udphdr = (struct libnet_udp_hdr *)(packet + IPV4_H + g_hdr_len);
 
     fprintf(stdout, "UDP header:  Src Port: %d  Dst Port: %d  Len: %d  ",
         htons(udphdr->uh_sport),

--- a/src/shape_arp_hdr.c
+++ b/src/shape_arp_hdr.c
@@ -29,8 +29,8 @@ libnet_t *
 shape_arp_hdr(libnet_t *pkt_d)
 {
     u_int32_t i, s_paddr, r_paddr;
-    u_int8_t s_neaddr[6];
-    u_int8_t r_neaddr[6];
+    char s_neaddr[6];
+    char r_neaddr[6];
 
     struct libnet_ether_addr *hw_addr;
 
@@ -151,11 +151,11 @@ shape_arp_hdr(libnet_t *pkt_d)
         6,
         4,
         ahdr_o.op_type,
-        s_neaddr,
+        (const u_int8_t *) s_neaddr,
         (u_int8_t *)&s_paddr,
-        r_neaddr,
+        (const u_int8_t *) r_neaddr,
         (u_int8_t *)&r_paddr,
-        payload,
+        (const u_int8_t *) payload,
         payload_len,
         pkt_d,
         0) == -1)

--- a/src/shape_ethernet_hdr.c
+++ b/src/shape_ethernet_hdr.c
@@ -65,12 +65,12 @@ shape_ethernet_hdr(libnet_t *pkt_d)
 
     if(ehdr_o.d_addr == NULL
        && (injection_type == ETHERTYPE_ARP || injection_type == ETHERTYPE_REVARP))
-        ehdr_o.d_addr = ETH_BROADCAST; // TODO: this is wrong.. we should use malloc instead
+        ehdr_o.d_addr = ETH_BROADCAST;
     else
     if(ehdr_o.d_addr == NULL)
     {
         fprintf(stderr, "Warning: Using NULL destination ethernet address. Packets may not reach their destination\n");
-        ehdr_o.d_addr = ETH_DEFAULT; // TODO: this is wrong.. we should use malloc instead
+        ehdr_o.d_addr = ETH_DEFAULT;
     }
 
     if(format_ethernet_addr(ehdr_o.d_addr, ud_addr) == 0)

--- a/src/shape_ethernet_hdr.c
+++ b/src/shape_ethernet_hdr.c
@@ -30,8 +30,8 @@ libnet_t *
 shape_ethernet_hdr(libnet_t *pkt_d)
 {
     int i;
-    u_int8_t us_addr[6];
-    u_int8_t ud_addr[6];
+    char us_addr[6];
+    char ud_addr[6];
 	
     struct libnet_ether_addr *hw_addr;
 
@@ -65,12 +65,12 @@ shape_ethernet_hdr(libnet_t *pkt_d)
 
     if(ehdr_o.d_addr == NULL
        && (injection_type == ETHERTYPE_ARP || injection_type == ETHERTYPE_REVARP))
-        ehdr_o.d_addr = ETH_BROADCAST;
+        ehdr_o.d_addr = ETH_BROADCAST; // TODO: this is wrong.. we should use malloc instead
     else
     if(ehdr_o.d_addr == NULL)
     {
         fprintf(stderr, "Warning: Using NULL destination ethernet address. Packets may not reach their destination\n");
-        ehdr_o.d_addr = ETH_DEFAULT;
+        ehdr_o.d_addr = ETH_DEFAULT; // TODO: this is wrong.. we should use malloc instead
     }
 
     if(format_ethernet_addr(ehdr_o.d_addr, ud_addr) == 0)
@@ -80,8 +80,8 @@ shape_ethernet_hdr(libnet_t *pkt_d)
         ud_addr[0], ud_addr[1], ud_addr[2], ud_addr[3], ud_addr[4], ud_addr[5]);
 
     if(libnet_build_ethernet(
-        ud_addr,
-        us_addr,
+        (const u_int8_t *) ud_addr,
+        (const u_int8_t *) us_addr,
         injection_type,
         NULL,
         0,

--- a/src/shape_icmpv4_hdr.c
+++ b/src/shape_icmpv4_hdr.c
@@ -53,13 +53,13 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
             if(i4hdr_o.rand_id)
                 i4hdr_o.id = (u_int16_t)retrieve_rand_int(P_UINT16);
 
-            hdr_len = ICMPV4_ECHO_H;
+            g_hdr_len = ICMPV4_ECHO_H;
 
-            if(pkt_len)
+            if(g_pkt_len)
             {
-                payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+                payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
                 payload_len = strlen(payload);
-                pkt_len = 0;
+                g_pkt_len = 0;
             }
 
             if(libnet_build_icmpv4_echo(
@@ -68,7 +68,7 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
 	        0,
 	        i4hdr_o.id,
 	        i4hdr_o.seqn,
-	        payload,
+	        (const u_int8_t *) payload,
 	        payload_len,
 	        pkt_d,
 	        0) == -1)
@@ -132,13 +132,13 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
                 fprintf(stdout, "DEBUG: Building ICMP unreachable header\n");
 #endif
 
-                hdr_len = ICMPV4_UNREACH_H;
+                g_hdr_len = ICMPV4_UNREACH_H;
 
-                if(pkt_len)
+                if(g_pkt_len)
                 {
-                    payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+                    payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
                     payload_len = strlen(payload);
-                    pkt_len = 0;
+                    g_pkt_len = 0;
                 }
 
                 if(libnet_build_ipv4(
@@ -187,13 +187,13 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
                 if((ihn_gw = libnet_name2addr4(pkt_d, i4hdr_o.gw, 1)) == -1)
 	            fatal_error("Invalid gateway IP address: %s", i4hdr_o.gw);
 
-                hdr_len = ICMPV4_REDIRECT_H;
+                g_hdr_len = ICMPV4_REDIRECT_H;
 
-                if(pkt_len)
+                if(g_pkt_len)
                 {
-                    payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+                    payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
                     payload_len = strlen(payload);
-                    pkt_len = 0;
+                    g_pkt_len = 0;
                 }
 
                 if(libnet_build_ipv4(
@@ -234,13 +234,13 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
                 fprintf(stdout, "DEBUG: Building ICMP timelimit exceeded header\n");
 #endif
 
-                hdr_len = ICMPV4_TIMXCEED_H;
+                g_hdr_len = ICMPV4_TIMXCEED_H;
 
-                if(pkt_len)
+                if(g_pkt_len)
                 {
-                    payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+                    payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
                     payload_len = strlen(payload);
-                    pkt_len = 0;
+                    g_pkt_len = 0;
                 }
 
                 if(libnet_build_ipv4(
@@ -287,13 +287,13 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
             if(i4hdr_o.rand_id)
                 i4hdr_o.id = (u_int16_t)retrieve_rand_int(P_UINT16);
 
-            hdr_len = ICMPV4_TSTAMP_H;
+            g_hdr_len = ICMPV4_TSTAMP_H;
 
-            if(pkt_len)
+            if(g_pkt_len)
             {
-                payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+                payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
                 payload_len = strlen(payload);
-                pkt_len = 0;
+                g_pkt_len = 0;
             }
 
             if(libnet_build_icmpv4_timestamp(
@@ -305,7 +305,7 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
 		i4hdr_o.otime,
 		i4hdr_o.rtime,
 		i4hdr_o.ttime,
-		payload,
+		(const u_int8_t *) payload,
 		payload_len,
 		pkt_d,
 		0) == -1)
@@ -330,13 +330,13 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
                 if((ihn_mask = libnet_name2addr4(pkt_d, i4hdr_o.mask, 1)) == -1)
 	            fatal_error("Invalid mask address: %s", i4hdr_o.mask);
 
-            hdr_len = ICMPV4_MASK_H;
+            g_hdr_len = ICMPV4_MASK_H;
 
-            if(pkt_len)
+            if(g_pkt_len)
             {
-                payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+                payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
                 payload_len = strlen(payload);
-                pkt_len = 0;
+                g_pkt_len = 0;
             }
 
 	    if(libnet_build_icmpv4_mask(
@@ -346,7 +346,7 @@ shape_icmpv4_hdr(libnet_t *pkt_d)
 	        i4hdr_o.id,
 	        i4hdr_o.seqn,
 		ihn_mask,
-	        payload,
+	        (const u_int8_t *) payload,
 	        payload_len,
 	        pkt_d,
 	        0) == -1)

--- a/src/shape_ipv4_hdr.c
+++ b/src/shape_ipv4_hdr.c
@@ -65,17 +65,17 @@ shape_ipv4_hdr(libnet_t *pkt_d)
     if(ip4hdr_o.rand_id)
         ip4hdr_o.id = (u_int16_t)retrieve_rand_int(P_UINT16);
 
-    if(rawip && pkt_len)
+    if(rawip && g_pkt_len)
     {
-        payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+        payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
         payload_len = strlen(payload);
-        pkt_len = 0;
+        g_pkt_len = 0;
     }
 
-    hdr_len = hdr_len + IPV4_H + payload_len;
+    g_hdr_len = g_hdr_len + IPV4_H + payload_len;
 
     if(libnet_build_ipv4(
-        hdr_len,
+        g_hdr_len,
         ip4hdr_o.tos,
         ip4hdr_o.id,
         ip4hdr_o.frag,
@@ -84,7 +84,7 @@ shape_ipv4_hdr(libnet_t *pkt_d)
         ip4hdr_o.sum,
         ip4hdr_o.n_saddr,
         ip4hdr_o.n_daddr,
-        (rawip) ? payload : NULL,
+        (rawip) ? (const u_int8_t *) payload : NULL,
         (rawip) ? payload_len : 0,
         pkt_d,
         0) == -1)

--- a/src/shape_tcp_hdr.c
+++ b/src/shape_tcp_hdr.c
@@ -35,7 +35,7 @@ shape_tcp_hdr(libnet_t *pkt_d)
 #endif
 
     ip4hdr_o.p = IPPROTO_TCP;
-    hdr_len = TCP_H;
+    g_hdr_len = TCP_H;
 
     if(rand_s_port)
         s_port = (u_int16_t)retrieve_rand_int(P_UINT16);
@@ -50,11 +50,11 @@ shape_tcp_hdr(libnet_t *pkt_d)
 
     // If packet length is provided, create a packet with a sequence
     // as payload
-    if(pkt_len)
+    if(g_pkt_len)
     {
-        payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+        payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
         payload_len = strlen(payload);
-        pkt_len = 0;
+        g_pkt_len = 0;
     }
 
     if(libnet_build_tcp(
@@ -66,8 +66,8 @@ shape_tcp_hdr(libnet_t *pkt_d)
         thdr_o.win,
         0,
         thdr_o.urp,
-        hdr_len + payload_len,
-        payload,
+        g_hdr_len + payload_len,
+        (const u_int8_t *) payload,
         payload_len,
         pkt_d,
         0) == -1)

--- a/src/shape_udp_hdr.c
+++ b/src/shape_udp_hdr.c
@@ -32,7 +32,7 @@ shape_udp_hdr(libnet_t *pkt_d)
     fprintf(stdout, "DEBUG: shape_udp_hdr()\n");
 #endif
 
-    hdr_len = UDP_H;
+    g_hdr_len = UDP_H;
     ip4hdr_o.p = IPPROTO_UDP;
 
     if(rand_d_port)
@@ -43,19 +43,19 @@ shape_udp_hdr(libnet_t *pkt_d)
 
     // If packet length is provided, create a packet with a sequence
     // as payload
-    if(pkt_len)
+    if(g_pkt_len)
     {
-        payload = generate_padding(hdr_len + IPV4_H, pkt_len);
+        payload = generate_padding(g_hdr_len + IPV4_H, g_pkt_len);
         payload_len = strlen(payload);
-        pkt_len = 0;
+        g_pkt_len = 0;
     }
 
     if(libnet_build_udp(
         s_port,
         d_port,
-        hdr_len + payload_len,
+        g_hdr_len + payload_len,
         0,
-        payload,
+        (const u_int8_t *) payload,
         payload_len,
         pkt_d,
         0) == -1)

--- a/src/stats.c
+++ b/src/stats.c
@@ -38,39 +38,39 @@ injection_stats()
 
     memset(&ln_stats, 0, sizeof(struct libnet_stats));
 
-    if(p_mode == M_TRACE)
+    if(g_p_mode == M_TRACE)
         print_separator(1, 1, "Trace Route Statistics");
     else
-        print_separator((p_mode == M_INJECT_RESPONSE) ? 1 : 2, 1, "Packet Injection Statistics");
+        print_separator((g_p_mode == M_INJECT_RESPONSE) ? 1 : 2, 1, "Packet Injection Statistics");
 
     libnet_stats(pkt_d, &ln_stats);
 
     if((tm_diff = af_pcap.tv_sec - bf_pcap.tv_sec) == 0)
         tm_diff = 1;
 
-    if(p_mode == M_INJECT)
-        fprintf(stdout, "Injected: %llu  Packets/Sec: %llu.%llu  Bytes/Sec: %llu.%llu  ",
+    if(g_p_mode == M_INJECT)
+        fprintf(stdout, "Injected: %lu  Packets/Sec: %lu.%lu  Bytes/Sec: %lu.%lu  ",
             (u_int64_t)ln_stats.packets_sent,
             (u_int64_t)ln_stats.packets_sent / tm_diff,
             (u_int64_t)ln_stats.packets_sent % tm_diff,
             (u_int64_t)ln_stats.bytes_written / tm_diff,
             (u_int64_t)ln_stats.bytes_written % tm_diff);
     else
-    if(p_mode == M_INJECT_RESPONSE)
+    if(g_p_mode == M_INJECT_RESPONSE)
     {
-        fprintf(stdout, "Injected: %llu  Received: %llu  Loss: %llu.%llu%%  Bytes Written: %llu  ",
-            (u_int64_t)ln_stats.packets_sent, cap_cnt,
-            (u_int64_t)(ln_stats.packets_sent == 0) ? 0 : (100 - (cap_cnt * 100) / ln_stats.packets_sent),
-            (u_int64_t)(cap_cnt * 100) % ln_stats.packets_sent,
+        fprintf(stdout, "Injected: %lu  Received: %lu  Loss: %lu.%lu%%  Bytes Written: %lu  ",
+            (u_int64_t)ln_stats.packets_sent, g_cap_cnt,
+            (u_int64_t)(ln_stats.packets_sent == 0) ? 0 : (100 - (g_cap_cnt * 100) / ln_stats.packets_sent),
+            (u_int64_t)(g_cap_cnt * 100) % ln_stats.packets_sent,
             (u_int64_t)ln_stats.bytes_written);
     }
     else
-    if(p_mode == M_TRACE)
-        fprintf(stdout, "Hop Count: %llu  Responses: %llu  Bytes Written: %llu  ",
-            inj_cnt, cap_cnt,
+    if(g_p_mode == M_TRACE)
+        fprintf(stdout, "Hop Count: %lu  Responses: %lu  Bytes Written: %lu  ",
+            g_inj_cnt, g_cap_cnt,
             (u_int64_t)ln_stats.bytes_written);
 
-    fprintf(stdout, "Errors: %llu",
+    fprintf(stdout, "Errors: %lu",
         (u_int64_t)ln_stats.packet_errors);
 
     fprintf(stdout, "\n");
@@ -89,12 +89,12 @@ capture_stats()
 
     memset(&p_stats, 0, sizeof(struct pcap_stat));
 
-    pcap_stats(pkt, &p_stats);
+    pcap_stats(g_pkt, &p_stats);
 
     print_separator(0, 1, "Packet Capture Statistics");
 
-    fprintf(stdout, "Received: %u  Dropped: %u  Processed: %llu",
-        p_stats.ps_recv, p_stats.ps_drop, inj_cnt);
+    fprintf(stdout, "Received: %u  Dropped: %u  Processed: %lu",
+        p_stats.ps_recv, p_stats.ps_drop, g_inj_cnt);
 
     fprintf(stdout, "\n");
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -75,8 +75,8 @@ retrieve_datalink_hdr_len(u_int32_t d_link)
     return len;
 }
 
-u_int8_t *
-retrieve_rand_ipv4_addr(u_int8_t *ip)
+char *
+retrieve_rand_ipv4_addr(char *ip)
 {
     u_int8_t oct, oct_cnt;
 
@@ -105,8 +105,8 @@ retrieve_rand_ipv4_addr(u_int8_t *ip)
     return ip;
 }
 
-u_int8_t *
-retrieve_rand_ethernet_addr(u_int8_t *eaddr)
+char *
+retrieve_rand_ethernet_addr(char *eaddr)
 {
     u_int16_t oct, oct_cnt;
 
@@ -128,12 +128,12 @@ retrieve_rand_ethernet_addr(u_int8_t *eaddr)
 }
 
 void
-print_separator(int bnl, int anl, u_int8_t *msgp, ...)
+print_separator(int bnl, int anl, const char *msgp, ...)
 {
     u_int16_t i;
     u_int16_t max_len = 76;
     u_int16_t msg_len = 0;
-    u_int8_t msg[255];
+    char msg[255];
 
     va_list va;
 
@@ -160,16 +160,16 @@ print_separator(int bnl, int anl, u_int8_t *msgp, ...)
     return;
 }
 
-u_int8_t *
+char *
 retrieve_icmp_code(u_int16_t type, u_int16_t code)
 {
-    u_int8_t *icmp_c;
+    char *icmp_c;
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: retrieve_icmp_code()\n");
 #endif
 
-    icmp_c = malloc(sizeof(u_int8_t) * 32);
+    icmp_c = malloc(32);
 
     if(type == ICMP_UNREACH)
     {
@@ -310,10 +310,10 @@ retrieve_icmp_code(u_int16_t type, u_int16_t code)
     return icmp_c;
 }
 
-u_int8_t *
+char *
 retrieve_icmp_type(u_int16_t type)
 {
-    u_int8_t *icmp_t;
+    char *icmp_t;
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: retrieve_icmp_type()\n");
@@ -396,16 +396,16 @@ retrieve_icmp_type(u_int16_t type)
     return icmp_t;
 }
 
-u_int8_t *
+char *
 retrieve_arp_type(u_int16_t op_type)
 {
-    u_int8_t *arp_t;
+    char *arp_t;
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: retrieve_arp_type() OPTYPE: %d\n", op_type);
 #endif
 
-    arp_t = malloc(sizeof(u_int8_t) * 32);
+    arp_t = malloc(32);
 
     switch(op_type)
     {
@@ -445,16 +445,16 @@ retrieve_arp_type(u_int16_t op_type)
     return arp_t;
 }
 
-u_int8_t *
+char *
 retrieve_arp_hw_type(u_int16_t hw_type)
 {
-    u_int8_t *hw_t;
+    char *hw_t;
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: retrieve_arp_hw_type() HWTYPE: %d\n", hw_type);
 #endif
 
-    hw_t = malloc(sizeof(u_int8_t) * 32);
+    hw_t = malloc(32);
 
     switch(hw_type)
     {
@@ -549,12 +549,12 @@ retrieve_tcp_flags()
 }
 
 u_int32_t
-format_ethernet_addr(char *ethstr, u_int8_t u_eaddr[6])
+format_ethernet_addr(char *ethstr, char u_eaddr[6])
 {
     int i = 0;
     long base16;
-    u_int8_t *eptr, *delim = ":";
-    u_int8_t o_ethstr[18] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    char *eptr, *delim = ":";
+    char o_ethstr[18] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: format_ethernet_addr()\n");
@@ -665,11 +665,11 @@ generate_padding(u_int16_t clen, u_int16_t dlen)
 }
 
 u_int32_t
-format_hex_payload(u_int8_t *string)
+format_hex_payload(char *string)
 {
-    u_int8_t *i, pl[65535];
-    u_int8_t *delim = " ";
-    u_int8_t tchar[2];
+    char *i, pl[65535];
+    char *delim = " ";
+    char tchar[2];
     long c;
     u_int32_t len = 0;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,19 +32,19 @@
 #include "capture_defs.h"
 #include "pcap.h"
 
-void print_separator(int, int, u_int8_t *, ...);
-u_int8_t *retrieve_rand_ipv4_addr(u_int8_t *);
-u_int8_t *retrieve_rand_ethernet_addr(u_int8_t *);
-u_int8_t *retrieve_arp_hw_type(u_int16_t);
-u_int8_t *retrieve_arp_type(u_int16_t);
-u_int8_t *retrieve_icmp_type(u_int16_t);
-u_int8_t *retrieve_icmp_code(u_int16_t, u_int16_t);
+void print_separator(int, int, const char *, ...);
+char *retrieve_rand_ipv4_addr(char *);
+char *retrieve_rand_ethernet_addr(char *);
+char *retrieve_arp_hw_type(u_int16_t);
+char *retrieve_arp_type(u_int16_t);
+char *retrieve_icmp_type(u_int16_t);
+char *retrieve_icmp_code(u_int16_t, u_int16_t);
 char *generate_padding(u_int16_t, u_int16_t);
-u_int32_t format_hex_payload(u_int8_t *);
+u_int32_t format_hex_payload(char *);
 u_int16_t parse_port_range(char *);
 u_int16_t retrieve_datalink_hdr_len(u_int32_t);
 u_int32_t retrieve_rand_int(u_int32_t);
-u_int32_t format_ethernet_addr(char *, u_int8_t[]);
+u_int32_t format_ethernet_addr(char *, char[]);
 int retrieve_tcp_flags();
 
 #endif /* __UTILS_H */


### PR DESCRIPTION
The change has:
1. Fix for [https://github.com/eribertomota/packit/issues/2] in src/globals.h (fixing the definition of ETH_BROADCAST and ETH_DEFAULT).
2. Fixing most compiler warnings by replacing all complaining u_int8_t definitions to char. Explicit u_int8_t is added where needed (when calling some libnet functions).
3. Added the prefix of "g_" to some of the global variables to make reading the code easier. This should also make reading capture_init() saner whose argument names were the same as global variables (please review that change closely).

The compilation was also tested with ```./configure --enable-debug && make``` which exposed some more compiler warnings in the debug logging fprintf()s (and they have been fixed too).