### PR TITLE
Redefining ETH_BROADCAST and ETH_DEFAULT for correct behavior

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -53,7 +53,8 @@
 #define IPV4_DEFAULT                    0x00000000		/* 0.0.0.0 */
 #define IPV4_BROADCAST                  "255.255.255.255"
 #define MASK_DEFAULT                    "255.255.255.0"
-#define ETH_DEFAULT                     0x000000000000		/* 00:00:00:00:00:00 */
+#define ETH_DEFAULT                     "00:00:00:00:00:00"
+#define ETH_BROADCAST                   "ff:ff:ff:ff:ff:ff"
 
 #define ARP_H            		0x1c    /* ARP header:          28 bytes */
 #define DNS_H                 		0xc     /* DNS header base:     12 bytes */

--- a/src/init.c
+++ b/src/init.c
@@ -35,9 +35,9 @@ injection_struct_init()
     memset(&ahdr_o, 0, sizeof(struct arphdr_opts));
     ahdr_o.op_type = ARPOP_REQUEST;
     ahdr_o.s_paddr = IPV4_DEFAULT;
-    ahdr_o.s_eaddr = ETH_DEFAULT;
+    ahdr_o.s_eaddr = (u_int8_t *) ETH_DEFAULT;
     ahdr_o.r_paddr = IPV4_DEFAULT;
-    ahdr_o.r_eaddr = ETH_DEFAULT;
+    ahdr_o.r_eaddr = (u_int8_t *) ETH_DEFAULT;
 
     memset(&ip4hdr_o, 0, sizeof(struct ip4hdr_opts));
     ip4hdr_o.ttl = (p_mode == M_INJECT) ? 128 : 1;

--- a/src/injection.c
+++ b/src/injection.c
@@ -45,7 +45,7 @@ injection_init()
 
 #ifdef DEBUG
     fprintf(stdout, "DEBUG: injection_init()\n");
-    fprintf(stdout, "DEBUG: cnt: %lld, interval_sec %d\n", cnt, interval_sec);
+    fprintf(stdout, "DEBUG: cnt: %ld, interval_sec %d\n", cnt, interval_sec);
     fprintf(stdout, "DEBUG: p_mode: %d  burst_rate: %d\n", p_mode, burst_rate);
 #endif
 
@@ -144,7 +144,7 @@ with_response(u_int32_t port_range)
     for(i = 1; i < cnt + 1; i++)
     {
 #ifdef DEBUG
-        fprintf(stdout, "DEBUG: for() inj_cnt: %lld  cnt: %lld\n", inj_cnt, cnt);
+        fprintf(stdout, "DEBUG: for() inj_cnt: %ld  cnt: %ld\n", inj_cnt, cnt);
 #endif
 
         if(dstp) i = 0;

--- a/src/shape_arp_hdr.c
+++ b/src/shape_arp_hdr.c
@@ -89,7 +89,7 @@ shape_arp_hdr(libnet_t *pkt_d)
 		break;
 
 	    default:
-                ahdr_o.s_eaddr = ETH_DEFAULT;
+                ahdr_o.s_eaddr = (u_int8_t *) ETH_DEFAULT;
                 break;
         }
     }
@@ -134,7 +134,7 @@ shape_arp_hdr(libnet_t *pkt_d)
 		break;
 
 	    default:
-                ahdr_o.r_eaddr = ETH_DEFAULT;
+                ahdr_o.r_eaddr = (u_int8_t *) ETH_DEFAULT;
 		break;
 	}
     }

--- a/src/shape_ethernet_hdr.c
+++ b/src/shape_ethernet_hdr.c
@@ -65,14 +65,13 @@ shape_ethernet_hdr(libnet_t *pkt_d)
 
     if(ehdr_o.d_addr == NULL
        && (injection_type == ETHERTYPE_ARP || injection_type == ETHERTYPE_REVARP)) {
-            ehdr_o.d_addr = malloc(6);
-            memset(ehdr_o.d_addr, 0xff, 6);
+            ehdr_o.d_addr = (u_int8_t *) ETH_BROADCAST;
         }
     else
     if(ehdr_o.d_addr == NULL)
     {
         fprintf(stderr, "Warning: Using NULL destination ethernet address. Packets may not reach their destination\n");
-        ehdr_o.d_addr = ETH_DEFAULT;
+        ehdr_o.d_addr = (u_int8_t *) ETH_DEFAULT;
     }
 
     if(format_ethernet_addr(ehdr_o.d_addr, ud_addr) == 0)


### PR DESCRIPTION
The ETH_DEFAULT assignment was wrong as well. Keeping it in style with IPV4_DEFAULT, IPV4_BROADCAST, ...

Fixing formatting string to remove compile time warnings when debug logging is
enabled at compile time.
