### PR TITLE
Avoid buffer overrun when formatting hex payload

### DIFF
--- a/src/injection.c
+++ b/src/injection.c
@@ -58,7 +58,7 @@ injection_init()
 
     if(g_hex_payload)
     {
-        if((g_payload_len = format_hex_payload(g_payload)) == 0)
+        if((g_payload_len = format_hex_payload((char *)g_payload)) == 0)
             fprintf(stdout, "Warning: Hex payload formatted incorrectly.\n");
     }
     else if(g_payload)

--- a/src/utils.c
+++ b/src/utils.c
@@ -650,9 +650,9 @@ unsigned char *generate_padding(u_int16_t clen, u_int16_t dlen)
     return string;
 }
 
-u_int32_t format_hex_payload(u_int8_t *string)
+u_int32_t format_hex_payload(char *string)
 {
-    u_int8_t pl[65535];
+    char *pl;
     char *i, *delim = " ";
     char tchar[2];
     long c;
@@ -662,21 +662,21 @@ u_int32_t format_hex_payload(u_int8_t *string)
     fprintf(stdout, "DEBUG: format_hex_payload()\n");
 #endif
 
-    memcpy(pl, string, 65535);
+    pl = strdup(string);
     pl[0] = pl[1] = 20;
 
-    memset(string, 0, 65535);
+    memset(string, 0, strlen(string));
     memset(tchar, 0, 2);
 
     /*
      * skip the first 3 chars because we know they are spaces
      */
-    for(i = strtok((char*)(pl+3), delim); i; i = strtok(NULL, delim)) {
+    for(i = strtok(pl+3, delim); i; i = strtok(NULL, delim)) {
         if((c = strtol(i, 0, 16)) > 0xff)
             return 0;
 
         sprintf(tchar,"%c",(u_int8_t)c);
-        strncpy((char*)(string+len),tchar,2);
+        strncpy(string+len,tchar,2);
         len++;
     }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,7 +40,7 @@ char *retrieve_arp_type(u_int16_t);
 char *retrieve_icmp_type(u_int16_t);
 char *retrieve_icmp_code(u_int16_t, u_int16_t);
 u_int8_t *generate_padding(u_int16_t, u_int16_t);
-u_int32_t format_hex_payload(u_int8_t *);
+u_int32_t format_hex_payload(char *);
 u_int16_t parse_port_range(char *);
 u_int16_t retrieve_datalink_hdr_len(u_int32_t);
 u_int32_t retrieve_rand_int(u_int32_t);


### PR DESCRIPTION
Hi Eriberto,

I ran into a buffer overrun when using packit 1.5-2 on Ubuntu 18.04. 

```
$ packit -p '0x 00'
packit: malloc.c:2401: sysmalloc: Assertion '(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.
Aborted (core dumped)
```

The culprit seems to be that g_payload is zeroed without taking into account the actual length of the string, which is fixed with this patch.

Let me know if you want me to update the Changelog and/or other files as well.